### PR TITLE
Add Support for Mixed, Nested, and TypedArray Inputs in Blob Constructor

### DIFF
--- a/blob-module/example/components/CreateBlobTest.tsx
+++ b/blob-module/example/components/CreateBlobTest.tsx
@@ -9,15 +9,12 @@ export function CreateBlobTestComponent() {
 		endings: "native",
 	});
 
-	const non_unicode = "\u0061\u030A";
-	const input_arr = new TextEncoder().encode(non_unicode);
-
-	const mixedBlob = new Blob([input_arr], {
+	const mixedBlob = new Blob([blob, "abc"], {
 		type: "test/plain",
 		endings: "native",
 	});
 
-	mixedBlob?.text().then((text) => {
+	mixedBlob?.text().then((text: string) => {
 		console.log(text);
 		setBlobText(text);
 	});

--- a/blob-module/example/components/CreateBlobTest.tsx
+++ b/blob-module/example/components/CreateBlobTest.tsx
@@ -9,14 +9,19 @@ export function CreateBlobTestComponent() {
 		endings: "native",
 	});
 
-	blob?.text().then((text) => {
+	const mixedBlob = new Blob([blob, "cd"], {
+		type: "test/plain",
+		endings: "native",
+	});
+
+	mixedBlob?.text().then((text) => {
 		setBlobText(text);
 	});
 
 	return (
 		<View style={styles.container}>
-			<Text>Size: {blob?.size}</Text>
-			<Text>Type: {blob?.type}</Text>
+			<Text>Size: {mixedBlob?.size}</Text>
+			<Text>Type: {mixedBlob?.type}</Text>
 			<Text>Text: {blobText}</Text>
 		</View>
 	);

--- a/blob-module/example/components/CreateBlobTest.tsx
+++ b/blob-module/example/components/CreateBlobTest.tsx
@@ -9,12 +9,16 @@ export function CreateBlobTestComponent() {
 		endings: "native",
 	});
 
-	const mixedBlob = new Blob([blob, "cd"], {
+	const non_unicode = "\u0061\u030A";
+	const input_arr = new TextEncoder().encode(non_unicode);
+
+	const mixedBlob = new Blob([input_arr], {
 		type: "test/plain",
 		endings: "native",
 	});
 
 	mixedBlob?.text().then((text) => {
+		console.log(text);
 		setBlobText(text);
 	});
 

--- a/blob-module/example/components/CreateBlobTest.tsx
+++ b/blob-module/example/components/CreateBlobTest.tsx
@@ -4,7 +4,7 @@ import { ExpoBlob as Blob } from "blob-module";
 
 export function CreateBlobTestComponent() {
 	const [blobText, setBlobText] = useState<string | null>(null);
-	const blob = new Blob(["a", "bbb", "d"], {
+	const blob = new Blob(["a", "bbb", "d", ["edf", ["aaaa"]]], {
 		type: "test/plain",
 		endings: "native",
 	});

--- a/blob-module/example/components/SliceBlobTest.tsx
+++ b/blob-module/example/components/SliceBlobTest.tsx
@@ -6,14 +6,12 @@ export function SliceBlobTestComponent() {
 	const [blobText, setBlobText] = useState<string | null>(null);
 	const [slicedBlobText, setSlicedBlobText] = useState<string | null>(null);
 
-	const blob = new Blob(["PASSSTRING"], {
-		type: "test/plain",
+	const blob = new Blob(["PASS"], {
+		type: "text/plain",
 		endings: "native",
 	});
 
-	const slicedBlob = blob.slice(0, -6);
-
-	// 1 - 5 -> 1,2,3,4
+	const slicedBlob = blob.slice(0, 4, "text/plain");
 
 	slicedBlob.text().then((text) => {
 		setSlicedBlobText(text);
@@ -25,8 +23,8 @@ export function SliceBlobTestComponent() {
 
 	return (
 		<View style={styles.container}>
-			<Text>Size: {blob?.size}</Text>
-			<Text>Type: {blob?.type}</Text>
+			<Text>Size: {slicedBlob?.size}</Text>
+			<Text>Type: {slicedBlob?.type}</Text>
 			<Text>Text before slice: {blobText}</Text>
 			<Text>Text after slice: {slicedBlobText}</Text>
 		</View>

--- a/blob-module/example/components/SliceBlobTest.tsx
+++ b/blob-module/example/components/SliceBlobTest.tsx
@@ -11,7 +11,7 @@ export function SliceBlobTestComponent() {
 		endings: "native",
 	});
 
-	const slicedBlob = blob.slice(0, 4, "text/plain");
+	const slicedBlob = blob.slice(0, 4, "tex\x09t/plain");
 
 	slicedBlob.text().then((text) => {
 		setSlicedBlobText(text);

--- a/blob-module/example/components/SliceBlobTest.tsx
+++ b/blob-module/example/components/SliceBlobTest.tsx
@@ -6,12 +6,14 @@ export function SliceBlobTestComponent() {
 	const [blobText, setBlobText] = useState<string | null>(null);
 	const [slicedBlobText, setSlicedBlobText] = useState<string | null>(null);
 
-	const blob = new Blob(["aaa", "bbbb", "ccccc", "dddddddddd"], {
+	const blob = new Blob(["PASSSTRING"], {
 		type: "test/plain",
 		endings: "native",
 	});
 
-	const slicedBlob = blob.slice(0, 8);
+	const slicedBlob = blob.slice(0, -6);
+
+	// 1 - 5 -> 1,2,3,4
 
 	slicedBlob.text().then((text) => {
 		setSlicedBlobText(text);
@@ -26,7 +28,7 @@ export function SliceBlobTestComponent() {
 			<Text>Size: {blob?.size}</Text>
 			<Text>Type: {blob?.type}</Text>
 			<Text>Text before slice: {blobText}</Text>
-			<Text>Text after slice [0-8]: {slicedBlobText}</Text>
+			<Text>Text after slice: {slicedBlobText}</Text>
 		</View>
 	);
 }

--- a/blob-module/example/components/SliceBlobTest.tsx
+++ b/blob-module/example/components/SliceBlobTest.tsx
@@ -6,12 +6,19 @@ export function SliceBlobTestComponent() {
 	const [blobText, setBlobText] = useState<string | null>(null);
 	const [slicedBlobText, setSlicedBlobText] = useState<string | null>(null);
 
-	const blob = new Blob(["PASS"], {
+	const blob1 = new Blob(["squiggle"]);
+	const arrayBuffer = new ArrayBuffer(16);
+	const int8View = new Int8Array(arrayBuffer);
+	for (var i = 0; i < 16; i++) {
+		int8View[i] = i + 65;
+	}
+
+	const blob = new Blob([new Uint8Array(arrayBuffer, 3, 5), blob1, "foo"], {
 		type: "text/plain",
 		endings: "native",
 	});
 
-	const slicedBlob = blob.slice(0, 4, "tex\x09t/plain");
+	const slicedBlob = blob.slice(0, 8, "tex\x09t/plain");
 
 	slicedBlob.text().then((text) => {
 		setSlicedBlobText(text);

--- a/blob-module/example/components/StreamBlobTest.tsx
+++ b/blob-module/example/components/StreamBlobTest.tsx
@@ -9,9 +9,9 @@ export function StreamBlobTestComponent() {
 	const blob = new Blob(["aaa", "bbbb"], {
 		type: "test/plain",
 		endings: "native",
-	});
+	}).slice(0, 5);
 
-	blob.text().then((text) => {
+	blob.text().then((text: string) => {
 		setBlobText(text);
 	});
 

--- a/blob-module/ios/Blob.swift
+++ b/blob-module/ios/Blob.swift
@@ -19,85 +19,96 @@ public class Blob: SharedObject {
   }
   
   func slice(start: Int = 0, end: Int? = nil, contentType: String? = nil) -> Blob {
-      let blobSize = self.size
-      var relativeStart = start
-    
-      if relativeStart < 0 {
-          relativeStart = max(blobSize + relativeStart, 0)
-      } else {
-          relativeStart = min(relativeStart, blobSize)
-      }
+    let blobSize = self.size
+    var relativeStart = start
+  
+    if relativeStart < 0 {
+      relativeStart = max(blobSize + relativeStart, 0)
+    } else {
+      relativeStart = min(relativeStart, blobSize - 1)
+    }
 
-      var relativeEnd = end ?? blobSize
-      if relativeEnd < 0 {
-          relativeEnd = max(blobSize + relativeEnd - 1, 0)
-      } else {
-          relativeEnd = min(relativeEnd, blobSize) - 1
-      }
+    var relativeEnd = (end ?? blobSize) - 1
+    if relativeEnd < 0 {
+      relativeEnd = max(blobSize + relativeEnd - 1, 0)
+    } else {
+      relativeEnd = min(relativeEnd, blobSize - 1)
+    }
 
-      let span = max(relativeEnd - relativeStart, 0)
-      if span == 0 {
-          let type = normalizedContentType(contentType)
-          return Blob(blobParts: [], options: BlobOptions(type: type, endings: self.options.endings))
-      }
-
-      var dataSlice: [BlobPart] = []
-      var currentPos = 0
-      var remaining = span
-
-      for part in blobParts {
-          let partSize = part.size()
-          if currentPos + partSize <= relativeStart {
-              currentPos += partSize
-              continue
-          }
-          if remaining <= 0 {
-              break
-          }
-          let partStart = max(0, relativeStart - currentPos)
-          let partEnd = min(partSize, partStart + remaining)
-          let length = partEnd - partStart
-          if length <= 0 {
-              currentPos += partSize
-              continue
-          }
-
-          switch part {
-          case .string(let str):
-              let utf8 = Array(str.utf8)
-            let subUtf8 = Array(utf8[partStart...partStart+length])
-              if let subStr = String(bytes: subUtf8, encoding: .utf8) {
-                  dataSlice.append(.string(subStr))
-              }
-          case .data(let data):
-              let subData = data.subdata(in: partStart..<partStart+length+1)
-              dataSlice.append(.data(subData))
-          case .typedArray(let typedArray):
-              if partStart == 0 && length == typedArray.byteLength {
-                  dataSlice.append(.typedArray(typedArray))
-              } else {
-                  let rawPtr = typedArray.rawPointer.advanced(by: partStart)
-                  let buffer = UnsafeBufferPointer<UInt8>(start: rawPtr.assumingMemoryBound(to: UInt8.self), count: length)
-                  let newData = Data(buffer: buffer)
-                  dataSlice.append(.data(newData))
-              }
-          case .blob(let blob):
-              let subBlob = blob.slice(start: partStart, end: partStart + length)
-              dataSlice.append(.blob(subBlob))
-          }
-
-          currentPos += partSize
-          remaining -= length
-      }
-    
+    let span = max(relativeEnd - relativeStart, 0)
+    if span == 0 {
       let type = normalizedContentType(contentType)
+      return Blob(blobParts: [], options: BlobOptions(type: type, endings: self.options.endings))
+    }
 
-      return Blob(blobParts: dataSlice, options: BlobOptions(type: type, endings: self.options.endings))
+    var dataSlice: [BlobPart] = []
+    var currentPos = 0
+    var remaining = span + 1
+
+    for part in blobParts {
+      let partSize = part.size()
+      if currentPos + partSize <= relativeStart {
+        currentPos += partSize
+        continue
+      }
+      if remaining <= 0 {
+        break
+      }
+      let partStart = max(0, relativeStart - currentPos)
+      let partEnd = min(partSize, partStart + remaining)
+      let length = partEnd - partStart
+      if length <= 0 {
+        currentPos += partSize
+        continue
+      }
+
+      switch part {
+        case .string(let str):
+          let utf8 = Array(str.utf8)
+          let subUtf8 = Array(utf8[partStart..<partStart+length])
+          if let subStr = String(bytes: subUtf8, encoding: .utf8) {
+            dataSlice.append(.string(subStr))
+          }
+          
+        case .data(let data):
+          let subData = data.subdata(in: partStart..<partStart+length)
+          dataSlice.append(.data(subData))
+          
+        case .typedArray(let typedArray):
+          if partStart == 0 && length == typedArray.byteLength {
+            dataSlice.append(.typedArray(typedArray))
+          } else {
+            let rawPtr = typedArray.rawPointer.advanced(by: partStart)
+            let buffer = UnsafeBufferPointer<UInt8>(start: rawPtr.assumingMemoryBound(to: UInt8.self), count: length)
+            let newData = Data(buffer: buffer)
+            dataSlice.append(.data(newData))
+          }
+        
+        case .blob(let blob):
+          let subBlob = blob.slice(start: partStart, end: partStart + length)
+          dataSlice.append(.blob(subBlob))
+      }
+        currentPos += partSize
+        remaining -= length
+    }
+  
+    let type = normalizedContentType(contentType)
+    return Blob(blobParts: dataSlice, options: BlobOptions(type: type, endings: self.options.endings))
   }
   
   func text() -> String {
     return blobParts.reduce("") { $0 + $1.text() }
   }
+}
+
+private func normalizedContentType(_ type: String?) -> String {
+    guard let type = type, !type.isEmpty else { return "" }
+    let ascii = type.utf8.allSatisfy { $0 >= 0x20 && $0 <= 0x7E }
+    let invalid = type.contains { $0 == "\u{00}" || $0 == "\u{0A}" || $0 == "\u{0D}" }
+    if !ascii || invalid {
+        return ""
+    }
+    return type.lowercased()
 }
 
 enum EndingType: String, Enumerable {
@@ -112,52 +123,3 @@ struct BlobOptions: Record {
   var endings: EndingType = .transparent
 }
 
-private func normalizedContentType(_ type: String?) -> String {
-    guard let type = type, !type.isEmpty else { return "" }
-    let ascii = type.utf8.allSatisfy { $0 >= 0x20 && $0 <= 0x7E }
-    let invalid = type.contains { $0 == "\u{00}" || $0 == "\u{0A}" || $0 == "\u{0D}" }
-    if !ascii || invalid {
-        return ""
-    }
-    return type.lowercased()
-}
-
-enum BlobPart {
-    case string(String)
-    case blob(Blob)
-    case data(Data)
-    case typedArray(TypedArray)
-}
-
-
-extension BlobPart {
-    func text() -> String {
-        switch self {
-        case .string(let str):
-            return str
-        case .data(let data):
-            return String(decoding: data, as: UTF8.self)
-        case .blob(let blob):
-            return blob.text()
-        case .typedArray(let typedArray):
-          let buffer = UnsafeBufferPointer<UInt8>(
-               start: typedArray.rawPointer.assumingMemoryBound(to: UInt8.self),
-               count: typedArray.byteLength
-           )
-          return String(decoding: buffer, as: UTF8.self)
-        }
-    }
-    
-    func size() -> Int {
-        switch self {
-        case .string(let str):
-            return str.lengthOfBytes(using: .utf8)
-        case .data(let data):
-             return data.count
-        case .blob(let blob):
-            return blob.size
-        case .typedArray(let typedArray):
-            return typedArray.byteLength
-        }
-    }
-}

--- a/blob-module/ios/Blob.swift
+++ b/blob-module/ios/Blob.swift
@@ -101,11 +101,21 @@ public class Blob: SharedObject {
   }
 }
 
+/// Normalizes the content type string for a Blob.
+/// - Returns: The lowercased content type if it is valid, or an empty string otherwise.
+/// - A valid content type:
+///   - Is not nil or empty
+///   - Contains only printable ASCII characters (0x20–0x7E)
+///   - Does not contain forbidden control characters: NUL (\x00), LF (\x0A), or CR (\x0D)
+/// If any of these conditions are not met, returns an empty string to indicate an invalid or unsafe content type.
 private func normalizedContentType(_ type: String?) -> String {
     guard let type = type, !type.isEmpty else { return "" }
-    let ascii = type.utf8.allSatisfy { $0 >= 0x20 && $0 <= 0x7E }
-    let invalid = type.contains { $0 == "\u{00}" || $0 == "\u{0A}" || $0 == "\u{0D}" }
-    if !ascii || invalid {
+    let asciiRange = "^[\\x20-\\x7E]+$"
+    let forbiddenChars = "[\\x00\\x0A\\x0D]"
+    if type.range(of: asciiRange, options: .regularExpression) == nil {
+        return ""
+    }
+    if type.range(of: forbiddenChars, options: .regularExpression) != nil {
         return ""
     }
     return type.lowercased()

--- a/blob-module/ios/Blob.swift
+++ b/blob-module/ios/Blob.swift
@@ -2,85 +2,87 @@ import Foundation
 import ExpoModulesCore
 
 public class Blob: SharedObject, BlobPart {
-    var blobParts: [BlobPart]
-    var options: BlobOptions
+  var blobParts: [BlobPart]
+  var options: BlobOptions
+  
+  init(blobParts: [BlobPart]?, options: BlobOptions?) {
+    self.blobParts = blobParts ?? []
+    self.options = options ?? BlobOptions()
+  }
+
+  var size: Int {
+    return blobParts.reduce(0) { $0 + $1.size }
+  }
+
+  var type: String {
+    return options.type
+  }
+
+  func slice(start: Int = 0, end: Int? = nil, contentType: String = "") -> Blob {
+    let startIdx = max(start, 0)
+    var endIdx = min(end ?? self.size - 1, self.size - 1)
+    let options = BlobOptions(type: contentType != "" ? contentType : self.options.type, endings: self.options.endings)
     
-    init(blobParts: [BlobPart]?, options: BlobOptions?) {
-        self.blobParts = blobParts ?? []
-        self.options = options ?? BlobOptions()
+    if endIdx < 0 {
+      endIdx = self.size - 1 + endIdx;
     }
 
-    var size: Int {
-        return blobParts.reduce(0) { $0 + $1.size }
-    }
-
-    var type: String {
-        return options.type
-    }
-
-    func slice(start: Int = 0, end: Int? = nil, contentType: String = "") -> Blob {
-        let startIdx = max(start, 0)
-        var endIdx = min(end ?? self.size - 1, self.size - 1)
-        let options = BlobOptions(type: contentType != "" ? contentType : self.options.type, endings: self.options.endings)
-        
-        if endIdx < 0 {
-            endIdx = self.size - 1 + endIdx;
-        }
-
-        if startIdx > endIdx || start == 0 && end == self.size - 1 {
-            return self
-        }
-        
-        var dataSlice: [BlobPart] = []
-        var charsLeft = endIdx - startIdx + 1
-        for part in blobParts {
-            if part.text().count <= charsLeft {
-                charsLeft -= part.text().count
-                dataSlice.append(part)
-            } else if charsLeft > 0 {
-                var partToAdd = ""
-                for char in part.text() {
-                    if charsLeft > 0 {
-                        charsLeft -= 1
-                        partToAdd += String(char)
-                    }
-                }
-                dataSlice.append(partToAdd)
-            } else {
-                break
-            }
-        }
-
-        return Blob(blobParts: dataSlice, options: options)
+    if startIdx > endIdx || start == 0 && end == self.size - 1 {
+      return self
     }
     
-    func text() -> String {
-        return blobParts.reduce("") { $0 + $1.text() }
+    var dataSlice: [BlobPart] = []
+    var charsLeft = endIdx - startIdx + 1
+    
+    for part in blobParts {
+      if part.text().count <= charsLeft {
+        charsLeft -= part.text().count
+        dataSlice.append(part)
+        
+      } else if charsLeft > 0 {
+        var partToAdd = ""
+        for char in part.text() {
+          if charsLeft > 0 {
+            charsLeft -= 1
+            partToAdd += String(char)
+          }
+        }
+        dataSlice.append(partToAdd)
+      } else {
+          break
+      }
     }
+
+    return Blob(blobParts: dataSlice, options: options)
+  }
+  
+  func text() -> String {
+    return blobParts.reduce("") { $0 + $1.text() }
+  }
 }
 
 enum EndingType: String, Enumerable {
-    case transparent = "transparent"
-    case native = "native"
+  case transparent = "transparent"
+  case native = "native"
 }
 
 struct BlobOptions: Record {
-    @Field
-    var type: String = ""
-    @Field
-    var endings: EndingType = .transparent
+  @Field
+  var type: String = ""
+  @Field
+  var endings: EndingType = .transparent
 }
 
 protocol BlobPart {
-    var size: Int { get }
-    func text() -> String
+  var size: Int { get }
+  func text() -> String
 }
 
 extension String: BlobPart {
-    var size: Int {
-        return self.count
-    }
-    func text() -> String {
-        return self
-    }
+  var size: Int {
+    return self.count
+  }
+  func text() -> String {
+    return self
+  }
 }

--- a/blob-module/ios/Blob.swift
+++ b/blob-module/ios/Blob.swift
@@ -78,10 +78,9 @@ public class Blob: SharedObject {
           if partStart == 0 && length == typedArray.byteLength {
             dataSlice.append(.typedArray(typedArray))
           } else {
-            let rawPtr = typedArray.rawPointer.advanced(by: partStart)
-            let buffer = UnsafeBufferPointer<UInt8>(start: rawPtr.assumingMemoryBound(to: UInt8.self), count: length)
-            let newData = Data(buffer: buffer)
-            dataSlice.append(.data(newData))
+            let data = Data(bytes: typedArray.rawPointer, count: typedArray.byteLength)
+            let subData = data.subdata(in: partStart..<partStart+length)
+            dataSlice.append(.data(subData))
           }
         
         case .blob(let blob):

--- a/blob-module/ios/Blob.swift
+++ b/blob-module/ios/Blob.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ExpoModulesCore
 
-public class Blob: SharedObject, BlobPart {
+public class Blob: SharedObject {
   var blobParts: [BlobPart]
   var options: BlobOptions
   
@@ -11,49 +11,88 @@ public class Blob: SharedObject, BlobPart {
   }
 
   var size: Int {
-    return blobParts.reduce(0) { $0 + $1.size }
+    return blobParts.reduce(0) { $0 + $1.size() }
   }
 
   var type: String {
     return options.type
   }
-
-  func slice(start: Int = 0, end: Int? = nil, contentType: String = "") -> Blob {
-    let startIdx = max(start, 0)
-    var endIdx = min(end ?? self.size - 1, self.size - 1)
-    let options = BlobOptions(type: contentType != "" ? contentType : self.options.type, endings: self.options.endings)
+  
+  func slice(start: Int = 0, end: Int? = nil, contentType: String? = nil) -> Blob {
+      let blobSize = self.size
+      var relativeStart = start
     
-    if endIdx < 0 {
-      endIdx = self.size - 1 + endIdx;
-    }
-
-    if startIdx > endIdx || start == 0 && end == self.size - 1 {
-      return self
-    }
-    
-    var dataSlice: [BlobPart] = []
-    var charsLeft = endIdx - startIdx + 1
-    
-    for part in blobParts {
-      if part.text().count <= charsLeft {
-        charsLeft -= part.text().count
-        dataSlice.append(part)
-        
-      } else if charsLeft > 0 {
-        var partToAdd = ""
-        for char in part.text() {
-          if charsLeft > 0 {
-            charsLeft -= 1
-            partToAdd += String(char)
-          }
-        }
-        dataSlice.append(partToAdd)
+      if relativeStart < 0 {
+          relativeStart = max(blobSize + relativeStart, 0)
       } else {
-          break
+          relativeStart = min(relativeStart, blobSize)
       }
-    }
 
-    return Blob(blobParts: dataSlice, options: options)
+      var relativeEnd = end ?? blobSize
+      if relativeEnd < 0 {
+          relativeEnd = max(blobSize + relativeEnd - 1, 0)
+      } else {
+          relativeEnd = min(relativeEnd, blobSize) - 1
+      }
+
+      let span = max(relativeEnd - relativeStart, 0)
+      if span == 0 {
+          let type = normalizedContentType(contentType)
+          return Blob(blobParts: [], options: BlobOptions(type: type, endings: self.options.endings))
+      }
+
+      var dataSlice: [BlobPart] = []
+      var currentPos = 0
+      var remaining = span
+
+      for part in blobParts {
+          let partSize = part.size()
+          if currentPos + partSize <= relativeStart {
+              currentPos += partSize
+              continue
+          }
+          if remaining <= 0 {
+              break
+          }
+          let partStart = max(0, relativeStart - currentPos)
+          let partEnd = min(partSize, partStart + remaining)
+          let length = partEnd - partStart
+          if length <= 0 {
+              currentPos += partSize
+              continue
+          }
+
+          switch part {
+          case .string(let str):
+              let utf8 = Array(str.utf8)
+            let subUtf8 = Array(utf8[partStart...partStart+length])
+              if let subStr = String(bytes: subUtf8, encoding: .utf8) {
+                  dataSlice.append(.string(subStr))
+              }
+          case .data(let data):
+              let subData = data.subdata(in: partStart..<partStart+length+1)
+              dataSlice.append(.data(subData))
+          case .typedArray(let typedArray):
+              if partStart == 0 && length == typedArray.byteLength {
+                  dataSlice.append(.typedArray(typedArray))
+              } else {
+                  let rawPtr = typedArray.rawPointer.advanced(by: partStart)
+                  let buffer = UnsafeBufferPointer<UInt8>(start: rawPtr.assumingMemoryBound(to: UInt8.self), count: length)
+                  let newData = Data(buffer: buffer)
+                  dataSlice.append(.data(newData))
+              }
+          case .blob(let blob):
+              let subBlob = blob.slice(start: partStart, end: partStart + length)
+              dataSlice.append(.blob(subBlob))
+          }
+
+          currentPos += partSize
+          remaining -= length
+      }
+    
+      let type = normalizedContentType(contentType)
+
+      return Blob(blobParts: dataSlice, options: BlobOptions(type: type, endings: self.options.endings))
   }
   
   func text() -> String {
@@ -73,16 +112,52 @@ struct BlobOptions: Record {
   var endings: EndingType = .transparent
 }
 
-protocol BlobPart {
-  var size: Int { get }
-  func text() -> String
+private func normalizedContentType(_ type: String?) -> String {
+    guard let type = type, !type.isEmpty else { return "" }
+    let ascii = type.utf8.allSatisfy { $0 >= 0x20 && $0 <= 0x7E }
+    let invalid = type.contains { $0 == "\u{00}" || $0 == "\u{0A}" || $0 == "\u{0D}" }
+    if !ascii || invalid {
+        return ""
+    }
+    return type.lowercased()
 }
 
-extension String: BlobPart {
-  var size: Int {
-    return self.count
-  }
-  func text() -> String {
-    return self
-  }
+enum BlobPart {
+    case string(String)
+    case blob(Blob)
+    case data(Data)
+    case typedArray(TypedArray)
+}
+
+
+extension BlobPart {
+    func text() -> String {
+        switch self {
+        case .string(let str):
+            return str
+        case .data(let data):
+            return String(decoding: data, as: UTF8.self)
+        case .blob(let blob):
+            return blob.text()
+        case .typedArray(let typedArray):
+          let buffer = UnsafeBufferPointer<UInt8>(
+               start: typedArray.rawPointer.assumingMemoryBound(to: UInt8.self),
+               count: typedArray.byteLength
+           )
+          return String(decoding: buffer, as: UTF8.self)
+        }
+    }
+    
+    func size() -> Int {
+        switch self {
+        case .string(let str):
+            return str.lengthOfBytes(using: .utf8)
+        case .data(let data):
+             return data.count
+        case .blob(let blob):
+            return blob.size
+        case .typedArray(let typedArray):
+            return typedArray.byteLength
+        }
+    }
 }

--- a/blob-module/ios/BlobModule.swift
+++ b/blob-module/ios/BlobModule.swift
@@ -2,39 +2,39 @@ import Foundation
 import ExpoModulesCore
 
 public class BlobModule: Module {
-    public func definition() -> ModuleDefinition {
-        Name("ExpoBlob")
-        
-        Class(Blob.self) {
-            Constructor { (blobParts: Either<[String], [Blob]>, options: BlobOptions?) in
-                if let blobPartsList: [String] = blobParts.get() {
-                    return Blob(blobParts: blobPartsList, options: options ?? BlobOptions())
-                }
-                else if let blobPartsSingleBlob: [Blob] = blobParts.get() {
-                    return Blob(blobParts: blobPartsSingleBlob, options: options ?? BlobOptions())
-                }
-                return Blob(blobParts: [], options: options ?? BlobOptions())
-            }
-            
-            Property("size") { (blob: Blob) in
-                blob.size
-            }
-            
-            Property("type") { (blob: Blob) in
-                blob.type
-            }
-            
-            Property("endings") { (blob: Blob) in
-                blob.options.endings
-            }
-            
-            Function("slice") { (blob: Blob, start: Int?, end: Int?, contentType: String?) in
-                blob.slice(start: start ?? 0, end: end ?? blob.size - 1, contentType: contentType ?? "")
-            }
-                
-            Function("text") { (blob: Blob) in
-                blob.text()
-            }
+  public func definition() -> ModuleDefinition {
+    Name("ExpoBlob")
+
+    Class(Blob.self) {
+      Constructor { (blobParts: Either<[String], [Blob]>, options: BlobOptions?) in
+        if let blobPartsList: [String] = blobParts.get() {
+          return Blob(blobParts: blobPartsList, options: options ?? BlobOptions())
         }
+        else if let blobPartsSingleBlob: [Blob] = blobParts.get() {
+          return Blob(blobParts: blobPartsSingleBlob, options: options ?? BlobOptions())
+        }
+        return Blob(blobParts: [], options: options ?? BlobOptions())
+      }
+      
+      Property("size") { (blob: Blob) in
+        blob.size
+      }
+      
+      Property("type") { (blob: Blob) in
+        blob.type
+      }
+      
+      Property("endings") { (blob: Blob) in
+        blob.options.endings
+      }
+      
+      Function("slice") { (blob: Blob, start: Int?, end: Int?, contentType: String?) in
+        blob.slice(start: start ?? 0, end: end ?? blob.size - 1, contentType: contentType ?? "")
+      }
+      
+      Function("text") { (blob: Blob) in
+        blob.text()
+      }
     }
+  }
 }

--- a/blob-module/ios/BlobModule.swift
+++ b/blob-module/ios/BlobModule.swift
@@ -28,10 +28,6 @@ public class BlobModule: Module {
         blob.type
       }
       
-      Property("endings") { (blob: Blob) in
-        blob.options.endings
-      }
-      
       Function("slice") { (blob: Blob, start: Int?, end: Int?, contentType: String?) in
         blob.slice(start: start ?? 0, end: end, contentType: contentType ?? "")
       }

--- a/blob-module/ios/BlobModule.swift
+++ b/blob-module/ios/BlobModule.swift
@@ -6,12 +6,12 @@ public class BlobModule: Module {
         Name("ExpoBlob")
         
         Class(Blob.self) {
-            Constructor { (blobParts: Either<[String], Blob>, options: BlobOptions?) in
+            Constructor { (blobParts: Either<[String], [Blob]>, options: BlobOptions?) in
                 if let blobPartsList: [String] = blobParts.get() {
                     return Blob(blobParts: blobPartsList, options: options ?? BlobOptions())
                 }
-                else if let blobPartsSingleBlob: Blob = blobParts.get() {
-                    return Blob(blobParts: [blobPartsSingleBlob], options: options ?? BlobOptions())
+                else if let blobPartsSingleBlob: [Blob] = blobParts.get() {
+                    return Blob(blobParts: blobPartsSingleBlob, options: options ?? BlobOptions())
                 }
                 return Blob(blobParts: [], options: options ?? BlobOptions())
             }

--- a/blob-module/ios/BlobModule.swift
+++ b/blob-module/ios/BlobModule.swift
@@ -6,14 +6,16 @@ public class BlobModule: Module {
     Name("ExpoBlob")
 
     Class(Blob.self) {
-      Constructor { (blobParts: [Either<String, Blob>]?, options: BlobOptions?) in
+      Constructor { (blobParts: [EitherOfThree<String, Blob, TypedArray>]?, options: BlobOptions?) in
         let blobPartsProcessed: [BlobPart]? = blobParts?.map { part in
           if let part: String = part.get() {
-            return part
+            return .string(part)
           } else if let part: Blob = part.get() {
-            return part
+            return .blob(part)
+          } else if let part: TypedArray = part.get() {
+            return .typedArray(part)
           }
-          return ""
+          return .string("")
         }
         return Blob(blobParts: blobPartsProcessed ?? [], options: BlobOptions())
       }

--- a/blob-module/ios/BlobModule.swift
+++ b/blob-module/ios/BlobModule.swift
@@ -6,14 +6,16 @@ public class BlobModule: Module {
     Name("ExpoBlob")
 
     Class(Blob.self) {
-      Constructor { (blobParts: Either<[String], [Blob]>, options: BlobOptions?) in
-        if let blobPartsList: [String] = blobParts.get() {
-          return Blob(blobParts: blobPartsList, options: options ?? BlobOptions())
+      Constructor { (blobParts: [Either<String, Blob>]?, options: BlobOptions?) in
+        let blobPartsProcessed: [BlobPart]? = blobParts?.map { part in
+          if let part: String = part.get() {
+            return part
+          } else if let part: Blob = part.get() {
+            return part
+          }
+          return ""
         }
-        else if let blobPartsSingleBlob: [Blob] = blobParts.get() {
-          return Blob(blobParts: blobPartsSingleBlob, options: options ?? BlobOptions())
-        }
-        return Blob(blobParts: [], options: options ?? BlobOptions())
+        return Blob(blobParts: blobPartsProcessed ?? [], options: BlobOptions())
       }
       
       Property("size") { (blob: Blob) in

--- a/blob-module/ios/BlobModule.swift
+++ b/blob-module/ios/BlobModule.swift
@@ -17,7 +17,7 @@ public class BlobModule: Module {
           }
           return .string("")
         }
-        return Blob(blobParts: blobPartsProcessed ?? [], options: BlobOptions())
+        return Blob(blobParts: blobPartsProcessed ?? [], options: options ?? BlobOptions())
       }
       
       Property("size") { (blob: Blob) in
@@ -33,7 +33,7 @@ public class BlobModule: Module {
       }
       
       Function("slice") { (blob: Blob, start: Int?, end: Int?, contentType: String?) in
-        blob.slice(start: start ?? 0, end: end ?? blob.size - 1, contentType: contentType ?? "")
+        blob.slice(start: start ?? 0, end: end, contentType: contentType ?? "")
       }
       
       Function("text") { (blob: Blob) in

--- a/blob-module/ios/BlobPart.swift
+++ b/blob-module/ios/BlobPart.swift
@@ -17,11 +17,7 @@ extension BlobPart {
       case .blob(let blob):
         return blob.text()
       case .typedArray(let typedArray):
-        let buffer = UnsafeBufferPointer<UInt8>(
-            start: typedArray.rawPointer.assumingMemoryBound(to: UInt8.self),
-            count: typedArray.byteLength
-         )
-        return String(decoding: buffer, as: UTF8.self)
+        return String(decoding: Data(bytes: typedArray.rawPointer, count: typedArray.byteLength), as: UTF8.self)
     }
   }
   

--- a/blob-module/ios/BlobPart.swift
+++ b/blob-module/ios/BlobPart.swift
@@ -1,0 +1,40 @@
+import ExpoModulesCore
+
+enum BlobPart {
+    case string(String)
+    case blob(Blob)
+    case data(Data)
+    case typedArray(TypedArray)
+}
+
+extension BlobPart {
+    func text() -> String {
+        switch self {
+        case .string(let str):
+            return str
+        case .data(let data):
+            return String(decoding: data, as: UTF8.self)
+        case .blob(let blob):
+            return blob.text()
+        case .typedArray(let typedArray):
+          let buffer = UnsafeBufferPointer<UInt8>(
+               start: typedArray.rawPointer.assumingMemoryBound(to: UInt8.self),
+               count: typedArray.byteLength
+           )
+          return String(decoding: buffer, as: UTF8.self)
+        }
+    }
+    
+    func size() -> Int {
+        switch self {
+        case .string(let str):
+            return str.lengthOfBytes(using: .utf8)
+        case .data(let data):
+             return data.count
+        case .blob(let blob):
+            return blob.size
+        case .typedArray(let typedArray):
+            return typedArray.byteLength
+        }
+    }
+}

--- a/blob-module/ios/BlobPart.swift
+++ b/blob-module/ios/BlobPart.swift
@@ -1,40 +1,40 @@
 import ExpoModulesCore
 
 enum BlobPart {
-    case string(String)
-    case blob(Blob)
-    case data(Data)
-    case typedArray(TypedArray)
+  case string(String)
+  case blob(Blob)
+  case data(Data)
+  case typedArray(TypedArray)
 }
 
 extension BlobPart {
-    func text() -> String {
-        switch self {
-        case .string(let str):
-            return str
-        case .data(let data):
-            return String(decoding: data, as: UTF8.self)
-        case .blob(let blob):
-            return blob.text()
-        case .typedArray(let typedArray):
-          let buffer = UnsafeBufferPointer<UInt8>(
-               start: typedArray.rawPointer.assumingMemoryBound(to: UInt8.self),
-               count: typedArray.byteLength
-           )
-          return String(decoding: buffer, as: UTF8.self)
-        }
+  func text() -> String {
+    switch self {
+      case .string(let str):
+        return str
+      case .data(let data):
+        return String(decoding: data, as: UTF8.self)
+      case .blob(let blob):
+        return blob.text()
+      case .typedArray(let typedArray):
+        let buffer = UnsafeBufferPointer<UInt8>(
+            start: typedArray.rawPointer.assumingMemoryBound(to: UInt8.self),
+            count: typedArray.byteLength
+         )
+        return String(decoding: buffer, as: UTF8.self)
     }
-    
-    func size() -> Int {
-        switch self {
-        case .string(let str):
-            return str.lengthOfBytes(using: .utf8)
-        case .data(let data):
-             return data.count
-        case .blob(let blob):
-            return blob.size
-        case .typedArray(let typedArray):
-            return typedArray.byteLength
-        }
+  }
+  
+  func size() -> Int {
+    switch self {
+    case .string(let str):
+      return str.lengthOfBytes(using: .utf8)
+    case .data(let data):
+      return data.count
+    case .blob(let blob):
+      return blob.size
+    case .typedArray(let typedArray):
+      return typedArray.byteLength
     }
+  }
 }

--- a/blob-module/src/BlobModule.ts
+++ b/blob-module/src/BlobModule.ts
@@ -3,9 +3,22 @@ import { Blob } from "./BlobModule.types";
 
 const NativeBlobModule: any = requireNativeModule("ExpoBlob");
 
+function flattenBlobParts(parts: any[]): any[] {
+	const result: any[] = [];
+	for (const part of parts) {
+		if (Array.isArray(part)) {
+			result.push(...flattenBlobParts(part));
+		} else {
+			result.push(part);
+		}
+	}
+	return result;
+}
+
 export class ExpoBlob extends NativeBlobModule.Blob implements Blob {
-	constructor(blobParts?: any, options?: BlobPropertyBag) {
-		super(blobParts, options);
+	constructor(blobParts?: any[], options?: BlobPropertyBag) {
+		const flatParts = blobParts ? flattenBlobParts(blobParts) : [];
+		super(flatParts, options);
 	}
 
 	slice(start?: number, end?: number, contentType?: string): Blob {

--- a/blob-module/src/BlobModule.ts
+++ b/blob-module/src/BlobModule.ts
@@ -1,24 +1,10 @@
 import { requireNativeModule } from "expo";
-import { Blob, BlobPart } from "./BlobModule.types";
+import { Blob } from "./BlobModule.types";
 
 const NativeBlobModule: any = requireNativeModule("ExpoBlob");
-
-function flattenBlobParts(parts: any[]): BlobPart[] {
-	const result: BlobPart[] = [];
-	for (const part of parts) {
-		if (Array.isArray(part)) {
-			result.push(...flattenBlobParts(part));
-		} else {
-			result.push(part);
-		}
-	}
-	return result;
-}
-
 export class ExpoBlob extends NativeBlobModule.Blob implements Blob {
 	constructor(blobParts?: any[], options?: BlobPropertyBag) {
-		const flatParts = blobParts ? flattenBlobParts(blobParts) : [];
-		super(flatParts, options);
+		super(blobParts?.flat(Infinity), options);
 	}
 
 	slice(start?: number, end?: number, contentType?: string): ExpoBlob {

--- a/blob-module/src/BlobModule.ts
+++ b/blob-module/src/BlobModule.ts
@@ -21,7 +21,7 @@ export class ExpoBlob extends NativeBlobModule.Blob implements Blob {
 		super(flatParts, options);
 	}
 
-	slice(start?: number, end?: number, contentType?: string): Blob {
+	slice(start?: number, end?: number, contentType?: string): ExpoBlob {
 		const slicedBlob = super.slice(start, end, contentType);
 		const options: BlobPropertyBag = {
 			type: slicedBlob.type,

--- a/blob-module/src/BlobModule.ts
+++ b/blob-module/src/BlobModule.ts
@@ -23,11 +23,8 @@ export class ExpoBlob extends NativeBlobModule.Blob implements Blob {
 
 	slice(start?: number, end?: number, contentType?: string): ExpoBlob {
 		const slicedBlob = super.slice(start, end, contentType);
-		const options: BlobPropertyBag = {
-			type: slicedBlob.type,
-			endings: slicedBlob.endings,
-		};
-		return new ExpoBlob([slicedBlob], options);
+		Object.setPrototypeOf(slicedBlob, ExpoBlob.prototype);
+		return slicedBlob;
 	}
 
 	async text(): Promise<string> {

--- a/blob-module/src/BlobModule.ts
+++ b/blob-module/src/BlobModule.ts
@@ -1,10 +1,10 @@
 import { requireNativeModule } from "expo";
-import { Blob } from "./BlobModule.types";
+import { Blob, BlobPart } from "./BlobModule.types";
 
 const NativeBlobModule: any = requireNativeModule("ExpoBlob");
 
-function flattenBlobParts(parts: any[]): any[] {
-	const result: any[] = [];
+function flattenBlobParts(parts: any[]): BlobPart[] {
+	const result: BlobPart[] = [];
 	for (const part of parts) {
 		if (Array.isArray(part)) {
 			result.push(...flattenBlobParts(part));
@@ -27,7 +27,7 @@ export class ExpoBlob extends NativeBlobModule.Blob implements Blob {
 			type: slicedBlob.type,
 			endings: slicedBlob.endings,
 		};
-		return new ExpoBlob(slicedBlob, options);
+		return new ExpoBlob([slicedBlob], options);
 	}
 
 	async text(): Promise<string> {


### PR DESCRIPTION
Constructor improvements:

- Added support for creating Blob instances from mixed-type arrays (e.g., strings, other blobs, typed arrays, and data).
- Enabled creation of Blob objects from nested arrays (arrays within arrays, recursively).
- Added support for initializing Blob from TypedArray objects.
- Refactored BlobPart from a protocol to an enum for more robust and type-safe handling of blob parts.